### PR TITLE
Fix selection breaks input issue.

### DIFF
--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
@@ -1,18 +1,3 @@
-/**
- * Copyright (c) 2019 Cotta & Cush Limited.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.cottacush.android.currencyedittext
 
 import android.content.Context
@@ -28,7 +13,7 @@ import java.util.*
 class CurrencyEditText(context: Context, attrs: AttributeSet?) : TextInputEditText(context, attrs) {
     private lateinit var currencySymbolPrefix: String
     private var textWatcher: CurrencyInputWatcher
-    private var locale: Locale = Locale.getDefault()
+    private var locale: Locale = Locale.US
 
     init {
         var useCurrencySymbolAsHint = false
@@ -44,7 +29,7 @@ class CurrencyEditText(context: Context, attrs: AttributeSet?) : TextInputEditTe
                 recycle()
             }
         }
-        currencySymbolPrefix = if (prefix.isBlank().not()) "$prefix " else ""
+        currencySymbolPrefix = prefix
         if (useCurrencySymbolAsHint) hint = currencySymbolPrefix
         if (isLollipopAndAbove() && !localeTag.isNullOrBlank()) locale = getLocaleFromTag(localeTag!!)
         textWatcher = CurrencyInputWatcher(this, currencySymbolPrefix, locale)
@@ -62,7 +47,7 @@ class CurrencyEditText(context: Context, attrs: AttributeSet?) : TextInputEditTe
     }
 
     fun setCurrencySymbol(currencySymbol: String, useCurrencySymbolAsHint: Boolean = false) {
-        currencySymbolPrefix = "$currencySymbol "
+        currencySymbolPrefix = currencySymbol
         if (useCurrencySymbolAsHint) hint = currencySymbolPrefix
         invalidateTextWatcher()
     }

--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
@@ -1,18 +1,3 @@
-/**
- * Copyright (c) 2019 Cotta & Cush Limited.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.cottacush.android.currencyedittext
 
 import android.annotation.SuppressLint

--- a/library/src/main/java/com/cottacush/android/currencyedittext/Utils.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/Utils.kt
@@ -1,18 +1,3 @@
-/**
- * Copyright (c) 2019 Cotta & Cush Limited.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.cottacush.android.currencyedittext
 
 import android.os.Build
@@ -29,8 +14,9 @@ internal fun parseMoneyValueWithLocale(
     groupingSeparator: String,
     currencySymbol: String
 ): Number {
+    val filteredNumbers = value.filter { it.isDigit() }
     val valueWithoutSeparator = parseMoneyValue(value, groupingSeparator, currencySymbol)
-    return NumberFormat.getInstance(locale).parse(valueWithoutSeparator)!!
+    return if (filteredNumbers.isBlank()) 0 else NumberFormat.getInstance(locale).parse(valueWithoutSeparator)!!
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)


### PR DESCRIPTION
Try to select before input field - dollar sign or space right after prefix - and it will break the logic. That's that this PR fixes

You can still remove space character after prefix. This also needs to be fixed.