### PR TITLE
Fix invalid input crash

### DIFF
--- a/library/src/main/java/com/cottacush/android/currencyedittext/Utils.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/Utils.kt
@@ -29,8 +29,9 @@ internal fun parseMoneyValueWithLocale(
     groupingSeparator: String,
     currencySymbol: String
 ): Number {
+    val filteredNumbers = value.filter { it.isDigit() }
     val valueWithoutSeparator = parseMoneyValue(value, groupingSeparator, currencySymbol)
-    return NumberFormat.getInstance(locale).parse(valueWithoutSeparator)!!
+    return if (filteredNumbers.isBlank()) 0 else NumberFormat.getInstance(locale).parse(valueWithoutSeparator)!!
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)


### PR DESCRIPTION
- $ .
- $

Those input causes crash. I simply filtered numbers and if there is no number, it returns 0