### PR TITLE
Pre-user Interaction setText() method calls

### DIFF
--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
@@ -84,6 +84,11 @@ class CurrencyEditText(context: Context, attrs: AttributeSet?) : TextInputEditTe
         ).toDoubleOrNull()
     }
 
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        super.setText(text, type)
+        getText()?.length?.let { setSelection(it) }
+    }
+
     override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
         if (focused) {

--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyEditText.kt
@@ -51,6 +51,7 @@ class CurrencyEditText(context: Context, attrs: AttributeSet?) : TextInputEditTe
         if (useCurrencySymbolAsHint) hint = currencySymbolPrefix
         if (isLollipopAndAbove() && !localeTag.isNullOrBlank()) locale = Locale.forLanguageTag(localeTag)
         textWatcher = CurrencyInputWatcher(this, currencySymbolPrefix, locale)
+        addTextChangedListener(textWatcher)
     }
 
     fun setLocale(locale: Locale) {


### PR DESCRIPTION
This PR fixes #14 by adding the text watcher as soon as the edittext is initialized. It also improves setText() method calls by moving the cursor to the end of the edit text after the method call.