### PR TITLE
Fix: Rounding Error On Display During Entry

### DIFF
--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
@@ -79,7 +79,7 @@ class CurrencyInputWatcher(
                     decimalFormatSymbols.groupingSeparator.toString(),
                     currencySymbol
                 )
-            val parsedNumber = fractionDecimalFormat.parse(numberWithoutGroupingSeparator)!!
+            val parsedNumber = numberWithoutGroupingSeparator.toBigDecimal()
             val selectionStartIndex = editText.selectionStart
             if (hasDecimalPoint) {
                 fractionDecimalFormat.applyPattern(


### PR DESCRIPTION
This Pull Request fixes Double's problem with accurately storing 1.0E23 in memory, storing 9.99999999999E22 instead. This is fixed by changing the parsed number during entry to BigDecimal from Double.
BigDecimal doesn't have a problem with storing 1.0E23 or any other number in memory accurately, fixing this problem. 

Another plus that comes with this fix is; Double has a limit of 1.0E308, which returns infinity after this point. BigDecimal can store as many numbers as you can type.

Fixes #17 
