### PR TITLE
Add custom logic to truncate extra decimal digits

### DIFF
--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
@@ -49,8 +49,7 @@ class CurrencyInputWatcher(
             applyPattern("#,##0")
         }
 
-    private val fractionDecimalFormat = (NumberFormat.getNumberInstance(locale) as DecimalFormat).apply {
-    }
+    private val fractionDecimalFormat = (NumberFormat.getNumberInstance(locale) as DecimalFormat)
 
     val decimalFormatSymbols: DecimalFormatSymbols
         get() = wholeNumberDecimalFormat.decimalFormatSymbols

--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyInputWatcher.kt
@@ -19,13 +19,11 @@ import android.annotation.SuppressLint
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
-import java.lang.IllegalArgumentException
-import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.text.NumberFormat
 import java.text.ParseException
-import java.util.Locale
+import java.util.*
 import kotlin.math.min
 
 class CurrencyInputWatcher(
@@ -49,11 +47,9 @@ class CurrencyInputWatcher(
     private val wholeNumberDecimalFormat =
         (NumberFormat.getNumberInstance(locale) as DecimalFormat).apply {
             applyPattern("#,##0")
-            roundingMode = RoundingMode.DOWN
         }
 
     private val fractionDecimalFormat = (NumberFormat.getNumberInstance(locale) as DecimalFormat).apply {
-        roundingMode = RoundingMode.DOWN
     }
 
     val decimalFormatSymbols: DecimalFormatSymbols
@@ -100,6 +96,13 @@ class CurrencyInputWatcher(
             if (numberWithoutGroupingSeparator == decimalFormatSymbols.decimalSeparator.toString()) {
                 numberWithoutGroupingSeparator = "0$numberWithoutGroupingSeparator"
             }
+
+            numberWithoutGroupingSeparator = truncateNumberToMaxDecimalDigits(
+                numberWithoutGroupingSeparator,
+                maxNumberOfDecimalPlaces,
+                decimalFormatSymbols.decimalSeparator
+            )
+
             val parsedNumber = fractionDecimalFormat.parse(numberWithoutGroupingSeparator)!!
             val selectionStartIndex = editText.selectionStart
             if (hasDecimalPoint) {

--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyRounder.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyRounder.kt
@@ -34,7 +34,7 @@ fun truncateNumberToMaxDecimalDigits(
     decimalSeparator: Char
 ): String {
     // Split number into whole and decimal part
-    var arr = number
+    val arr = number
         .split(decimalSeparator)
         .toMutableList()
 

--- a/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyRounder.kt
+++ b/library/src/main/java/com/cottacush/android/currencyedittext/CurrencyRounder.kt
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 Cotta & Cush Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cottacush.android.currencyedittext
+
+/**
+ * Helper method to truncate extra decimal digits from numbers.
+ * Was created because the previously used approach, [java.math.RoundingMode.DOWN] approach
+ * didn't work correctly for some devices.
+ *
+ * @param number the original number to format
+ * @param maxDecimalDigits the maximum number of decimal digits permitted
+ * @param decimalSeparator the decimal separator of the currently selected locale
+ * @return a version of number that has a maximum of [maxDecimalDigits] decimal digits.
+ * e.g.
+ * - 14.333 with 2 max decimal digits return 14.33
+ * - 19.2 with 2 max decimal digits return 19.2
+ */
+fun truncateNumberToMaxDecimalDigits(
+    number: String,
+    maxDecimalDigits: Int,
+    decimalSeparator: Char
+): String {
+    // Split number into whole and decimal part
+    var arr = number
+        .split(decimalSeparator)
+        .toMutableList()
+
+    // We should have exactly 2 elements in our string;
+    // the whole part and the decimal part
+    if (arr.size != 2) {
+        return number
+    }
+
+    // Take the first n (or shorter) from the decimal digits.
+    arr[1] = arr[1].take(maxDecimalDigits)
+
+    return arr.joinToString(separator = decimalSeparator.toString())
+}

--- a/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyInputWatcherTest.kt
+++ b/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyInputWatcherTest.kt
@@ -27,6 +27,7 @@ class CurrencyInputWatcherTest {
     // TODO Add more locale tests by their, tags, decimal separator and theur grouping separator
     private val locales = listOf(
             LocaleVars("en-NG", '.', ',', "$ "),
+            LocaleVars("en-US", '.', ',', "$ "),
             LocaleVars("da-DK", ',', '.', "$ "),
             LocaleVars("fr-CA", ',', ' ', "$ ")
     )
@@ -396,6 +397,23 @@ class CurrencyInputWatcherTest {
 
             verify(editText, times(1)).setText(firstExpectedText)
             verify(editText, times(1)).setText(secondExpectedText)
+        }
+    }
+
+    @Test
+    fun `Should retain valid number if imputed`() {
+        // This test tries to replicate issue #29 which fails on some devices and passes for some.
+        // It however passes on my local. but might be helpful to have the test in here.
+        for (locale in locales) {
+            val currentEditTextContent = "515${locale.decimalSeparator}809"
+            val expectedText = "${locale.currencySymbol}515${locale.decimalSeparator}809"
+
+            val (editText, editable, watcher) = setupTestVariables(locale, decimalPlaces = 3)
+            `when`(editable.toString()).thenReturn(currentEditTextContent)
+
+            watcher.runAllWatcherMethods(editable)
+
+            verify(editText, times(1)).setText(expectedText)
         }
     }
 

--- a/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
+++ b/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
@@ -78,5 +78,4 @@ class CurrencyRounderTest(
             truncateNumberToMaxDecimalDigits(current, decimalDigits, decimalSeparator)
         )
     }
-
 }

--- a/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
+++ b/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2019 Cotta & Cush Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cottacush.android.currencyedittext
+
+import org.junit.Assert
+import org.junit.Test
+
+class CurrencyRounderTest {
+
+    companion object {
+        const val POINT_DECIMAL_SEPARATOR = '.'
+        const val COMMA_DECIMAL_SEPARATOR = ','
+        const val TWO = 2
+        const val THREE = 3
+    }
+
+    @Test
+    fun `should return empty string if told to format empty string`() {
+        var current = ""
+        var expected = ""
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits away when given long digits`() {
+        var current = "223.55644234234"
+        var expected = "223.55"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits away when given long digits (three dp version)`() {
+        var current = "223.55644234234"
+        var expected = "223.556"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits away when given long digits (example 2)`() {
+        var current = "334,242,203.4234234"
+        var expected = "334,242,203.423"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits away when given long digits (whitespace decimal separator version)`() {
+        var current = "334 242 203.4234234"
+        var expected = "334 242 203.423"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits away when given long digits (comma decimal separator version)`() {
+        var current = "334.242.203,4234234"
+        var expected = "334.242.203,42"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, TWO, COMMA_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits when number with empty whole format is passed`() {
+        var current = ".4234234"
+        var expected = ".42"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should truncate extra decimal digits when number with empty decimal numbers is passed`() {
+        var current = "4234234."
+        var expected = "4234234."
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number with shorter decimal places is passed`() {
+        var current = "23.45"
+        var expected = "23.45"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number with shorter decimal places is passed (example 2)`() {
+        var current = "23.4"
+        var expected = "23.4"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number with shorter decimal places is passed (example 3)`() {
+        var current = "515.809"
+        var expected = "515.809"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number doesn't contain decimal separator`() {
+        var current = "5 809"
+        var expected = "5 809"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number doesn't contain decimal separator (example 2)`() {
+        var current = "5"
+        var expected = "5"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number doesn't contain decimal separator (example 3)`() {
+        var current = "5,452,635,242,242,423,434,333"
+        var expected = "5,452,635,242,242,423,434,333"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+
+    @Test
+    fun `should return original number when number contains more than one decimal separator`() {
+        var current = "343,432,242,342"
+        var expected = "343,432,242,342"
+
+        Assert.assertEquals(
+            expected,
+            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
+        )
+    }
+}

--- a/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
+++ b/library/src/test/java/com/cottacush/android/currencyedittext/CurrencyRounderTest.kt
@@ -17,178 +17,66 @@ package com.cottacush.android.currencyedittext
 
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class CurrencyRounderTest {
+@RunWith(Parameterized::class)
+class CurrencyRounderTest(
+    private val current: String,
+    private val expected: String,
+    private val decimalDigits: Int,
+    private val decimalSeparator: Char
+) {
 
     companion object {
-        const val POINT_DECIMAL_SEPARATOR = '.'
-        const val COMMA_DECIMAL_SEPARATOR = ','
-        const val TWO = 2
-        const val THREE = 3
-    }
+        private const val POINT_DECIMAL_SEPARATOR = '.'
+        private const val COMMA_DECIMAL_SEPARATOR = ','
+        private const val TWO = 2
+        private const val THREE = 3
 
-    @Test
-    fun `should return empty string if told to format empty string`() {
-        var current = ""
-        var expected = ""
+        private val emptyStringTestCase = arrayOf("", "", TWO, POINT_DECIMAL_SEPARATOR)
+        private val extraDecimalTestCase1 = arrayOf("223.55644234234", "223.55", TWO, POINT_DECIMAL_SEPARATOR)
+        private val extraDecimalTestCaseThreeDpVersion = arrayOf("223.55644234234", "223.556", THREE, POINT_DECIMAL_SEPARATOR)
+        private val extraDecimalTestCase2 = arrayOf("334,242,203.4234234", "334,242,203.423", THREE, POINT_DECIMAL_SEPARATOR)
+        private val extraDecimalTestCaseWhiteSpaceGrouping = arrayOf("334 242 203.4234234", "334 242 203.423", THREE, POINT_DECIMAL_SEPARATOR)
+        private val extraDecimalTestCaseCommaDecimal = arrayOf("334.242.203,4234234", "334.242.203,42", TWO, COMMA_DECIMAL_SEPARATOR)
+        private val emptyWholeTestCase = arrayOf(".4234234", ".42", TWO, POINT_DECIMAL_SEPARATOR)
+        private val emptyDecimalTestCase = arrayOf("4,234,234.", "4,234,234.", TWO, POINT_DECIMAL_SEPARATOR)
+        private val shorterDecimalTestCase = arrayOf("23.45", "23.45", THREE, POINT_DECIMAL_SEPARATOR)
+        private val shorterDecimalTestCase2 = arrayOf("23.4", "23.4", THREE, POINT_DECIMAL_SEPARATOR)
+        private val exactDecimalTestCase = arrayOf("515.809", "515.809", THREE, POINT_DECIMAL_SEPARATOR)
+        private val noDecimalTestCase = arrayOf("5 809", "5 809", THREE, POINT_DECIMAL_SEPARATOR)
+        private val noDecimalTestCase2 = arrayOf("5", "5", THREE, POINT_DECIMAL_SEPARATOR)
+        private val noDecimalTestCase3 = arrayOf("5,452,635,242,242,423,434,333", "5,452,635,242,242,423,434,333", THREE, POINT_DECIMAL_SEPARATOR)
+        private val multipleDecimalTestCase = arrayOf("343,432,242,342", "343,432,242,342", TWO, COMMA_DECIMAL_SEPARATOR)
 
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Iterable<Array<Any>> = listOf(
+            emptyStringTestCase,
+            extraDecimalTestCase1,
+            extraDecimalTestCaseThreeDpVersion,
+            extraDecimalTestCase2,
+            extraDecimalTestCaseWhiteSpaceGrouping,
+            extraDecimalTestCaseCommaDecimal,
+            emptyWholeTestCase,
+            emptyDecimalTestCase,
+            shorterDecimalTestCase,
+            shorterDecimalTestCase2,
+            exactDecimalTestCase,
+            noDecimalTestCase,
+            noDecimalTestCase2,
+            noDecimalTestCase3,
+            multipleDecimalTestCase
         )
     }
 
     @Test
-    fun `should truncate extra decimal digits away when given long digits`() {
-        var current = "223.55644234234"
-        var expected = "223.55"
-
+    fun `should return expected value for set of valid inputs`() {
         Assert.assertEquals(
             expected,
-            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
+            truncateNumberToMaxDecimalDigits(current, decimalDigits, decimalSeparator)
         )
     }
 
-    @Test
-    fun `should truncate extra decimal digits away when given long digits (three dp version)`() {
-        var current = "223.55644234234"
-        var expected = "223.556"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should truncate extra decimal digits away when given long digits (example 2)`() {
-        var current = "334,242,203.4234234"
-        var expected = "334,242,203.423"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should truncate extra decimal digits away when given long digits (whitespace decimal separator version)`() {
-        var current = "334 242 203.4234234"
-        var expected = "334 242 203.423"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should truncate extra decimal digits away when given long digits (comma decimal separator version)`() {
-        var current = "334.242.203,4234234"
-        var expected = "334.242.203,42"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, TWO, COMMA_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should truncate extra decimal digits when number with empty whole format is passed`() {
-        var current = ".4234234"
-        var expected = ".42"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should truncate extra decimal digits when number with empty decimal numbers is passed`() {
-        var current = "4234234."
-        var expected = "4234234."
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, TWO, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number with shorter decimal places is passed`() {
-        var current = "23.45"
-        var expected = "23.45"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number with shorter decimal places is passed (example 2)`() {
-        var current = "23.4"
-        var expected = "23.4"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number with shorter decimal places is passed (example 3)`() {
-        var current = "515.809"
-        var expected = "515.809"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number doesn't contain decimal separator`() {
-        var current = "5 809"
-        var expected = "5 809"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number doesn't contain decimal separator (example 2)`() {
-        var current = "5"
-        var expected = "5"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number doesn't contain decimal separator (example 3)`() {
-        var current = "5,452,635,242,242,423,434,333"
-        var expected = "5,452,635,242,242,423,434,333"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
-
-    @Test
-    fun `should return original number when number contains more than one decimal separator`() {
-        var current = "343,432,242,342"
-        var expected = "343,432,242,342"
-
-        Assert.assertEquals(
-            expected,
-            truncateNumberToMaxDecimalDigits(current, THREE, POINT_DECIMAL_SEPARATOR)
-        )
-    }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
             app:currencySymbol="$"
             app:useCurrencySymbolAsHint="true"
             app:localeTag="en-NG"
-            app:maxNumberOfDecimalDigits="2"
+            app:maxNumberOfDecimalDigits="3"
             android:layout_width="wrap_content"
             android:layout_height="60dp"
             android:ems="10"


### PR DESCRIPTION
There is an issue with using RoundingMode.DOWN to truncate extra decimal digits (to prevent RoundingMode.UP)
This Pull Request adds a custom helper method to truncate those extra decimal digits; tested extensively with Unit Tests.

Fixes #29 